### PR TITLE
chore: update sequelize to 6.x

### DIFF
--- a/lib/applications.js
+++ b/lib/applications.js
@@ -340,7 +340,7 @@ function setApplicationBoolean(key) {
 
         const dbResult = await req.application.update(
             toUpdate,
-            { returning: true, hooks: false }
+            { returning: ['*'], hooks: false }
         );
 
         // Recalculating votes per delegate for this antenna.
@@ -375,7 +375,7 @@ exports.setApplicationStatus = async (req, res) => {
 
     const dbResult = await req.application.update(
         { status: req.body.status },
-        { returning: true }
+        { returning: ['*'] }
     );
 
     // Recalculating votes per delegate for this antenna.
@@ -423,7 +423,7 @@ exports.setApplicationBoard = async (req, res) => {
             // First, saving the application.
             // If we've passed after this one, there's no duplicated, validations
             // and constraint take care about it.
-            const application = await req.application.update(toUpdate, { returning: true, transaction: t });
+            const application = await req.application.update(toUpdate, { returning: ['*'], transaction: t });
 
             // Recalculating votes per delegate for this antenna.
             await VotesPerAntenna.recalculateVotesForDelegates(req.event, req.application.body_id, t);
@@ -544,7 +544,7 @@ exports.setBoardForBody = async (req, res) => {
                 // First, saving the application.
                 // If we've passed after this one, there's no duplications, validations
                 // and constraint take care about it.
-                await application.update(toUpdate, { returning: true, transaction: t });
+                await application.update(toUpdate, { returning: ['*'], transaction: t });
 
                 // Checking is done in a helper.
                 await helpers.checkApplicationBoardviewValidity({

--- a/migrations/20190206083933-fix-pax-limits-unique-constraint.js
+++ b/migrations/20190206083933-fix-pax-limits-unique-constraint.js
@@ -7,8 +7,11 @@ module.exports = {
 
         await queryInterface.addConstraint(
             'pax_limits',
-            ['body_id', 'event_type'],
-            { type: 'unique', name: 'pax_limits_body_id_event_type_unique' }
+            {
+                type: 'unique',
+                name: 'pax_limits_body_id_event_type_unique',
+                fields: ['body_id', 'event_type']
+            }
         );
     },
     down: async (queryInterface) => {
@@ -19,8 +22,11 @@ module.exports = {
 
         await queryInterface.addConstraint(
             'pax_limits',
-            ['body_id'],
-            { type: 'unique', name: 'pax_limits_body_id_key' }
+            {
+                type: 'unique',
+                name: 'pax_limits_body_id_key',
+                fields: ['body_id'],
+            }
         );
     }
 };

--- a/migrations/20190210220317-add-unique-constraint-to-candidates.js
+++ b/migrations/20190210220317-add-unique-constraint-to-candidates.js
@@ -2,8 +2,11 @@ module.exports = {
     up: async (queryInterface) => {
         await queryInterface.addConstraint(
             'candidates',
-            ['position_id', 'user_id'],
-            { type: 'unique', name: 'candidates_position_id_user_id_unique' }
+            {
+                type: 'unique',
+                name: 'candidates_position_id_user_id_unique',
+                fields: ['position_id', 'user_id'],
+            }
         );
     },
     down: async (queryInterface) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3751,6 +3751,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -3759,7 +3760,8 @@
         "core-js": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-          "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+          "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==",
+          "dev": true
         }
       }
     },
@@ -3856,9 +3858,9 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -4280,15 +4282,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
       }
     },
     "co": {
@@ -8795,11 +8788,6 @@
           }
         }
       }
-    },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -16586,9 +16574,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -17322,7 +17310,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -18350,25 +18339,23 @@
       }
     },
     "sequelize": {
-      "version": "5.21.13",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.13.tgz",
-      "integrity": "sha512-wpwSpxzvADmgPkcOGeer5yFdAVsYeA7NLEw4evSXw03OlGL41J4S8hVz2/nilSWlJSwumlDGC9QbdwAmkWGqJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.3.0.tgz",
+      "integrity": "sha512-aVZUvT0w1ebewlApFuaUJE/fJ7aTfIpMnwNM/Zgr29QnY0fT1t0EjXxl48Fwmfq3BHJogLMhfMTJRXJQaiaFVQ==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
         "inflection": "1.12.0",
         "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
         "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.3.3",
+        "uuid": "^8.1.0",
         "validator": "^10.11.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -18385,36 +18372,35 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
         }
       }
     },
     "sequelize-cli": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-5.5.1.tgz",
-      "integrity": "sha512-ZM4kUZvY3y14y+Rq3cYxGH7YDJz11jWHcN2p2x7rhAIemouu4CEXr5ebw30lzTBtyXV4j2kTO+nUjZOqzG7k+Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-6.2.0.tgz",
+      "integrity": "sha512-6WQ2x91hg30dUn66mXHnzvHATZ4pyI1GHSNbS/TNN/vRR4BLRSLijadeMgC8zqmKDsL0VqzVVopJWfJakuP++Q==",
       "requires": {
-        "bluebird": "^3.5.3",
         "cli-color": "^1.4.0",
         "fs-extra": "^7.0.1",
         "js-beautify": "^1.8.8",
         "lodash": "^4.17.5",
         "resolve": "^1.5.0",
-        "umzug": "^2.1.0",
+        "umzug": "^2.3.0",
         "yargs": "^13.1.0"
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.0.0.tgz",
+      "integrity": "sha512-D/VfOX2Z+6JTWqM73lhcqMXp1X4CeqRNVMlndvbOMtyjFAZ2kYzH7rGFGFrLO1r+RZQdc/h+3zQL4nd3cclNLg=="
     },
     "serve-static": {
       "version": "1.14.1",
@@ -18492,11 +18478,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.2",
@@ -20036,12 +20017,11 @@
       }
     },
     "umzug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.2.0.tgz",
-      "integrity": "sha512-xZLW76ax70pND9bx3wqwb8zqkFGzZIK8dIHD9WdNy/CrNfjWcwQgQkGCuUqcuwEBvUm+g07z+qWvY+pxDmMEEw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.3.0.tgz",
+      "integrity": "sha512-Z274K+e8goZK8QJxmbRPhl89HPO1K+ORFtm6rySPhFKfKc5GHhqdzD0SGhSWHkzoXasqJuItdhorSvY7/Cgflw==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "bluebird": "^3.5.3"
+        "bluebird": "^3.7.2"
       }
     },
     "union-value": {
@@ -20339,9 +20319,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }
@@ -20500,9 +20480,9 @@
       }
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -20513,7 +20493,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -20542,9 +20522,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "request": "^2.88.2",
     "request-promise-native": "^1.0.8",
     "rimraf": "^3.0.2",
-    "sequelize": "^5.21.13",
-    "sequelize-cli": "^5.5.1"
+    "sequelize": "^6.3.0",
+    "sequelize-cli": "^6.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/test/api/applications-board.test.js
+++ b/test/api/applications-board.test.js
@@ -59,7 +59,7 @@ describe('Applications pax type/board comment', () => {
     });
 
     test('should succeed when the permissions are okay', async () => {
-        application = await application.update({ user_id: 1337 }, { returning: true });
+        application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -81,7 +81,7 @@ describe('Applications pax type/board comment', () => {
     test('should return 403 when user does not have permissions', async () => {
         mock.mockAll({ approvePermissions: { noPermissions: true }, mainPermissions: { noPermissions: true } });
 
-        application = await application.update({ user_id: 1337 }, { returning: true });
+        application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -186,7 +186,7 @@ describe('Applications pax type/board comment', () => {
             user_id: 1,
             participant_type: 'delegate',
             participant_order: 1
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const otherApplication = await generator.createApplication({
             user_id: 2,
@@ -212,7 +212,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({
             participant_type: 'delegate',
             participant_order: 1
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -240,7 +240,7 @@ describe('Applications pax type/board comment', () => {
             board_approve_deadline: moment().subtract(3, 'year').toDate(),
             starts: moment().subtract(2, 'year').toDate(),
             ends: moment().subtract(1, 'year').toDate(),
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -261,7 +261,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({
             participant_order: 1,
             participant_type: 'delegate'
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -354,7 +354,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({
             participant_order: 1,
             participant_type: 'delegate'
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -375,7 +375,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({
             participant_order: 1,
             participant_type: 'delegate'
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',
@@ -396,7 +396,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({
             participant_order: 1,
             participant_type: 'delegate'
-        }, { returning: true });
+        }, { returning: ['*'] });
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id + '/board',


### PR DESCRIPTION
apparently sequelize 6.x includes a few backwards-incompatible upgrades, and also we need to update it together with sequelize-cli. I've fixed it, should work now.

once this would be merged, we'll have 2 less PRs as dependabot will close them.