### PR TITLE
feat(metrics): added basic auth for /metrics/*. Fixes MEMB-670

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,10 +39,13 @@ services:
         labels:
             - "traefik.backend=statutory"
             - "traefik.port=8084"
+            - "traefik.auth.frontend.rule=PathPrefix:/api/statutory/metrics;PathPrefixStrip:/api/statutory;"
             - "traefik.old.frontend.rule=PathPrefixStrip:/services/oms-statutory/api;"
             - "traefik.new.frontend.rule=PathPrefixStrip:/api/statutory;"
+            - "traefik.auth.frontend.auth.basic.users=admin:${METRICS_CREDENTIALS}"
             - "traefik.old.frontend.priority=110"
             - "traefik.new.frontend.priority=110"
+            - "traefik.auth.frontend.priority=110"
             - "traefik.enable=true"
     statutory-static:
         restart: on-failure


### PR DESCRIPTION
Now we have 3 frontends:
1) legacy `/services/oms-statutory/api/*` (this would be removed in the future, I am unsure if we have somebody using it for now though)
2) new `/api/statutory/*`
3) metrics API - everything going in `/api/statutory/metrics/*` is protected with BasicAuth, so nobody can access these metrics not knowing the password.

`/services/oms-statutory/api/metrics` can be still accessed without authorization, but I'll deprecate and remove it in the future anyway, and if I'll password-protect it right now, it'll break current metrics logging, which I don't want to do.

I'm planning to do 3 more PRs (discounts, events, core) with the same content and a few more on AEGEE/MyAEGEE (with `.env.example` updated and with instructions on setting the password).

@linuxbandit need your approval for this one