### PR TITLE
fix(metrics): fix metrics basic auth priority

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,7 +45,7 @@ services:
             - "traefik.auth.frontend.auth.basic.users=admin:${METRICS_CREDENTIALS}"
             - "traefik.old.frontend.priority=110"
             - "traefik.new.frontend.priority=110"
-            - "traefik.auth.frontend.priority=110"
+            - "traefik.auth.frontend.priority=120"
             - "traefik.enable=true"
     statutory-static:
         restart: on-failure


### PR DESCRIPTION
apparently if you have 2 frontends with the same priority and the request matching both of them is done, it's not deterministic which frontend will serve the request, this should fix it