### PR TITLE
feat(question line): Allow users with permission to see question line

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -363,7 +363,8 @@ exports.getEventPermissions = (data) => {
     }
 
     permissions.manage_question_lines = hasPermission(corePermissions, 'global:manage_question_lines:' + event.type);
-    permissions.see_questions = permissions.manage_question_lines || (myApplication ? myApplication.confirmed : false);
+    permissions.see_question_lines = hasPermission(corePermissions, 'global:see_question_lines:' + event.type);
+    permissions.see_questions = permissions.manage_question_lines || permissions.see_question_lines || (myApplication ? myApplication.confirmed : false);
     permissions.submit_questions = myApplication ? myApplication.confirmed : false;
 
     return permissions;


### PR DESCRIPTION
Unless you are a confirmed participant of the Agora, or have the permission to manage question lines you can not see the question lists. This will allow members to see the question lines when they have the permission to do this. This is useful for candidates that are not participants of the Agora.