### PR TITLE
fix(circleci): update CircleCI config to use cimgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,19 @@
 orbs:
-  slack: circleci/slack@3.4.1
+  slack: circleci/slack@3.4.2
+  node: circleci/node@4.1.0
 version: 2.1
 jobs:
   test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
-      - run: docker run --name postgres -p 5432:5432 -d postgres:10.6
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
+      - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:13
+      - node/install:
+          node-version: 14.15.1
+      - node/install-packages:
+          cache-path: ~/node-modules
+          override-ci-command: npm install
       - run: mkdir -p ~/reports/jest
       - run:
           name: Run tests
@@ -27,23 +25,18 @@ jobs:
           path: ~/reports
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache statutory
   eslint:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/node:14.15
     steps:
       - checkout
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
+      - node/install-packages:
+          cache-path: ~/node-modules
+          override-ci-command: npm install
       - run: mkdir -p ~/reports
       - run: npm run lint -- --format junit --output-file ~/reports/eslint.xml
       - store_test_results:
@@ -51,25 +44,20 @@ jobs:
       - store_artifacts:
           path: ~/reports
   yamllint:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/python:3.9.0
     steps:
       - checkout
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
   docker-build-and-push:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/node:14.15
     steps:
       - checkout
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
+      - node/install-packages:
+          cache-path: ~/node-modules
+          override-ci-command: npm install
       - run: npx semantic-release
       - run: docker build  --tag aegee/statutory:$(node -p "require('./package.json').version") --tag aegee/statutory:latest -f docker/statutory/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ jobs:
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
   docker-build-and-push:
-    docker:
-      - image: cimg/node:14.15
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
       - node/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,4 @@ workflows:
               ignore: master
   docker-build-and-push:
     jobs:
-      - docker-build-and-push:
-          filters:
-            branches:
-              only: master
+      - docker-build-and-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,4 +89,7 @@ workflows:
               ignore: master
   docker-build-and-push:
     jobs:
-      - docker-build-and-push
+      - docker-build-and-push:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,7 @@ jobs:
             sudo apt-get install -y nodejs
             echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
             which node && node -v
-      - node/install-packages:
-          cache-path: ~/node-modules
-          override-ci-command: npm install
+      - node/install-packages
       - run: mkdir -p ~/reports/jest
       - run:
           name: Run tests
@@ -39,9 +37,7 @@ jobs:
       - image: cimg/node:14.15
     steps:
       - checkout
-      - node/install-packages:
-          cache-path: ~/node-modules
-          override-ci-command: npm install
+      - node/install-packages
       - run: mkdir -p ~/reports
       - run: npm run lint -- --format junit --output-file ~/reports/eslint.xml
       - store_test_results:
@@ -60,9 +56,7 @@ jobs:
       - image: cimg/node:14.15
     steps:
       - checkout
-      - node/install-packages:
-          cache-path: ~/node-modules
-          override-ci-command: npm install
+      - node/install-packages
       - run: npx semantic-release
       - run: docker build  --tag aegee/statutory:$(node -p "require('./package.json').version") --tag aegee/statutory:latest -f docker/statutory/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,13 @@ jobs:
     steps:
       - checkout
       - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:13
-      - node/install
+      - run:
+          name: Install Node
+          command: |
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
+            which node && node -v
       - node/install-packages:
           cache-path: ~/node-modules
           override-ci-command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,13 @@ orbs:
 version: 2.1
 jobs:
   test:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: cimg/node:14.15
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 19.03.13
       - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:13
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
       - node/install-packages
       - run: mkdir -p ~/reports/jest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,18 @@ orbs:
 version: 2.1
 jobs:
   test:
-    docker:
-      - image: cimg/node:14.15
+    machine:
+      image: ubuntu-2004:202010-01
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
       - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:13
+      - run:
+          name: Install Node
+          command: |
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
+            which node && node -v
       - node/install-packages
       - run: mkdir -p ~/reports/jest
       - run:
@@ -84,7 +89,4 @@ workflows:
               ignore: master
   docker-build-and-push:
     jobs:
-      - docker-build-and-push:
-          filters:
-            branches:
-              only: master
+      - docker-build-and-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
     steps:
       - checkout
       - run: docker run --name postgres -e POSTGRES_PASSWORD='5ecr3t' -p 5432:5432 -d postgres:13
-      - node/install:
-          node-version: 14.15.1
+      - node/install
       - node/install-packages:
           cache-path: ~/node-modules
           override-ci-command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,4 +85,7 @@ workflows:
               ignore: master
   docker-build-and-push:
     jobs:
-      - docker-build-and-push
+      - docker-build-and-push:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,12 @@ jobs:
       - store_artifacts:
           path: ~/reports
   build:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: cimg/base:2020.11
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 19.03.13
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache statutory
   eslint:
     docker:
@@ -52,10 +54,12 @@ jobs:
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
   docker-build-and-push:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: cimg/node:14.15
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 19.03.13
       - node/install-packages
       - run: npx semantic-release
       - run: docker build  --tag aegee/statutory:$(node -p "require('./package.json').version") --tag aegee/statutory:latest -f docker/statutory/Dockerfile .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
     postgres-statutory:
         restart: always
-        image: postgres:13
+        image: postgres:10.15
         volumes:
             - postgres-statutory:/var/lib/postgresql/data
         expose:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
     postgres-statutory:
         restart: always
-        image: postgres:10
+        image: postgres:13
         volumes:
             - postgres-statutory:/var/lib/postgresql/data
         expose:

--- a/docker/statutory/Dockerfile
+++ b/docker/statutory/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14.15.1
 
 RUN mkdir -p /usr/app/src \
 	&& mkdir -p /usr/app/media \

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
       "!lib/logger.js",
       "!lib/fs.js"
     ],
-    "testResultsProcessor": "jest-teamcity-reporter",
     "reporters": [
       "default",
       "jest-junit"
@@ -87,7 +86,6 @@
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "jest-teamcity-reporter": "^0.9.0",
     "nock": "^13.0.5",
     "nyc": "^15.1.0",
     "open-cli": "^6.0.1",


### PR DESCRIPTION
In hindsight I should have done this in two PRs, since the node and postgres versions are also affected (that's the reason why this is a fix instead of a chore)

I still want to tackle test in a later stage (especially since with the docker images we can run the tests in parallel, but I'm struggling with the test database), and the Slack orb is of an older version since the new version also has a completely different syntax