### PR TITLE
fix(memberslist): allow late submissions/edits to memberslist

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -357,8 +357,8 @@ exports.getEventPermissions = (data) => {
     for (const body of bodies) {
         permissions.set_board_comment_and_participant_type[body.id] = event.can_approve_members && approveBodiesList.includes(body.id);
         permissions.see_boardview[body.id] = approveBodiesList.includes(body.id);
-        permissions.upload_memberslist[body.id] = event.can_upload_memberslist && approveBodiesList.includes(body.id) && exports.isLocal(body);
-        permissions.edit_memberslist[body.id] = event.can_edit_memberslist && approveBodiesList.includes(body.id) && exports.isLocal(body);
+        permissions.upload_memberslist[body.id] = (event.can_upload_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
+        permissions.edit_memberslist[body.id] = (event.can_edit_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
         permissions.see_memberslist[body.id] = approveBodiesList.includes(body.id) && exports.isLocal(body);
     }
 

--- a/test/api/memberslist-upload.test.js
+++ b/test/api/memberslist-upload.test.js
@@ -155,6 +155,63 @@ describe('Memberslist uploading', () => {
         expect(res.body).toHaveProperty('data');
     });
 
+    test('should succeed if user has local late permission for his body on uploading new memberslist and the deadline has passed', async () => {
+        mock.mockAll({ mainPermissions: { latePermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(7, 'days'),
+            application_period_ends: moment().subtract(6, 'days'),
+            board_approve_deadline: moment().subtract(5, 'days'),
+            participants_list_publish_deadline: moment().subtract(4, 'days'),
+            memberslist_submission_deadline: moment().subtract(3, 'days'),
+            starts: moment().subtract(2, 'days'),
+            ends: moment().subtract(1, 'days')
+        });
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
+    test('should succeed if user has local late permission for his body on updating memberslist and the deadline has passed', async () => {
+        mock.mockAll({ mainPermissions: { latePermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(7, 'days'),
+            application_period_ends: moment().subtract(6, 'days'),
+            board_approve_deadline: moment().subtract(5, 'days'),
+            participants_list_publish_deadline: moment().subtract(4, 'days'),
+            memberslist_submission_deadline: moment().subtract(3, 'days'),
+            starts: moment().subtract(2, 'days'),
+            ends: moment().subtract(1, 'days')
+        });
+
+        await generator.createMembersList({
+            body_id: regularUser.bodies[0].id,
+            user_id: regularUser.id,
+            members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
     test('should discard fee_paid', async () => {
         mock.mockAll({ approvePermissions: { noPermissions: true } });
 

--- a/test/assets/core-permissions-late.json
+++ b/test/assets/core-permissions-late.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "data": [{
+        "scope": "local",
+        "object": "agora",
+        "id": 1,
+        "filters": [],
+        "description": "Upload and edit memberslist after the deadline for Agora statutory events.",
+        "combined": "local:memberslist_late:agora",
+        "circles": null,
+        "action": "memberslist_late"
+      }]
+}

--- a/test/scripts/mock-core-registry.js
+++ b/test/scripts/mock-core-registry.js
@@ -71,6 +71,13 @@ exports.mockCoreMainPermissions = (options) => {
             .replyWithFile(401, path.join(__dirname, '..', 'assets', 'core-unauthorized.json'));
     }
 
+    if (options.latePermissions) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/my_permissions')
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-permissions-late.json'));
+    }
+
     if (options.noPermissions) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()


### PR DESCRIPTION
Currently the only late submissions that are possible are from admins. The financial CD assistants would like to allow boards to also submit these with the correct permission.